### PR TITLE
Adding build number to cached result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
             <version>1.48</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20210307</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -7,16 +7,16 @@ import java.io.Serializable;
 public class CachedResult implements Serializable {
     private static final long serialVersionUID = 1L;
     private Result result;
-    private Number build_number;
+    private Integer buildNumber;
 
-    public CachedResult(Result result, Number build_number) {
+    public CachedResult(Result result, Integer buildNumber) {
         this.result = result;
-        this.build_number = build_number;
+        this.buildNumber = buildNumber;
     }
 
     public Result getCachedResult() { return result; }
-    public Number getBuildNumber() { return build_number; }
+    public Number getBuildNumber() { return buildNumber; }
 
     public void setCachedResult(Result result) { this.result = result; }
-    public void setBuild_number(Number build_number) { this.build_number = build_number; }
+    public void setBuildNumber(Integer buildNumber) { this.buildNumber = buildNumber; }
 }

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -1,0 +1,11 @@
+package hudson.plugins.resultscache;
+
+import hudson.model.Result;
+
+public class CachedResult {
+    public Result result;
+    public Number build_number;
+
+    public CachedResult(Result result, Number build_number) {
+    }
+}

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -15,7 +15,7 @@ public class CachedResult implements Serializable {
     }
 
     public Result getCachedResult() { return result; }
-    public Number getBuildNumber() { return buildNumber; }
+    public Integer getBuildNumber() { return buildNumber; }
 
     public void setCachedResult(Result result) { this.result = result; }
     public void setBuildNumber(Integer buildNumber) { this.buildNumber = buildNumber; }

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -7,5 +7,7 @@ public class CachedResult {
     public Number build_number;
 
     public CachedResult(Result result, Number build_number) {
+        this.result = result;
+        this.build_number = build_number;
     }
 }

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -2,7 +2,10 @@ package hudson.plugins.resultscache;
 
 import hudson.model.Result;
 
-public class CachedResult {
+import java.io.Serializable;
+
+public class CachedResult implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Result result;
     private Number build_number;
 

--- a/src/main/java/hudson/plugins/resultscache/CachedResult.java
+++ b/src/main/java/hudson/plugins/resultscache/CachedResult.java
@@ -3,11 +3,17 @@ package hudson.plugins.resultscache;
 import hudson.model.Result;
 
 public class CachedResult {
-    public Result result;
-    public Number build_number;
+    private Result result;
+    private Number build_number;
 
     public CachedResult(Result result, Number build_number) {
         this.result = result;
         this.build_number = build_number;
     }
+
+    public Result getCachedResult() { return result; }
+    public Number getBuildNumber() { return build_number; }
+
+    public void setCachedResult(Result result) { this.result = result; }
+    public void setBuild_number(Number build_number) { this.build_number = build_number; }
 }

--- a/src/main/java/hudson/plugins/resultscache/ResultsCacheBuildWrapper.java
+++ b/src/main/java/hudson/plugins/resultscache/ResultsCacheBuildWrapper.java
@@ -107,10 +107,11 @@ public class ResultsCacheBuildWrapper extends BuildWrapper {
         private void saveResultToCache(AbstractBuild build, TaskListener listener, String jobHash) {
             CacheServerComm cacheServer = new CacheServerComm(ResultsCacheHelper.getCacheServiceUrl(), ResultsCacheHelper.getTimeout());
             Result r = (null != build) ? build.getResult() : Result.NOT_BUILT;
-            LoggerUtil.info(listener, "(Post Build) Sending build result for this job (result: %s :: hash: %s) %n", r, jobHash);
+            Number num = (null != build) ? build.getNumber() : -1;
+            LoggerUtil.info(listener, "(Post Build) Sending build result for this job (result: %s :: job number: %s :: hash: %s) %n", r, num, jobHash);
 
             try {
-                cacheServer.postCachedResult(jobHash, r);
+                cacheServer.postCachedResult(jobHash, r, num);
                 LoggerUtil.info(listener, "(Update status: SUCCESS) Build result sent %n");
             } catch (IOException e) {
                 LoggerUtil.warn(listener, "(Update status: FAILURE) Unable to connect with cache server. Exception: %s %n", e.getMessage());

--- a/src/main/java/hudson/plugins/resultscache/ResultsCacheBuildWrapper.java
+++ b/src/main/java/hudson/plugins/resultscache/ResultsCacheBuildWrapper.java
@@ -107,7 +107,7 @@ public class ResultsCacheBuildWrapper extends BuildWrapper {
         private void saveResultToCache(AbstractBuild build, TaskListener listener, String jobHash) {
             CacheServerComm cacheServer = new CacheServerComm(ResultsCacheHelper.getCacheServiceUrl(), ResultsCacheHelper.getTimeout());
             Result r = (null != build) ? build.getResult() : Result.NOT_BUILT;
-            Number num = (null != build) ? build.getNumber() : -1;
+            Integer num = (null != build) ? build.getNumber() : -1;
             LoggerUtil.info(listener, "(Post Build) Sending build result for this job (result: %s :: job number: %s :: hash: %s) %n", r, num, jobHash);
 
             try {

--- a/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
+++ b/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
@@ -4,12 +4,18 @@
 
 package hudson.plugins.resultscache;
 
-import hudson.model.*;
 import org.apache.commons.lang.StringUtils;
 import java.io.IOException;
 import java.util.Collections;
 
 import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.Executor;
+import hudson.model.ParametersAction;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.StringParameterValue;
+import hudson.model.TaskListener;
 import hudson.plugins.resultscache.model.BuildConfig;
 import hudson.plugins.resultscache.util.CacheServerComm;
 import hudson.plugins.resultscache.util.HashCalculator;

--- a/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
+++ b/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
@@ -8,7 +8,7 @@ import hudson.model.*;
 import org.apache.commons.lang.StringUtils;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Optional;
+
 import hudson.FilePath;
 import hudson.plugins.resultscache.model.BuildConfig;
 import hudson.plugins.resultscache.util.CacheServerComm;
@@ -29,25 +29,25 @@ public class ResultsCacheHelper {
             CacheServerComm cacheServer = new CacheServerComm(getCacheServiceUrl(), getTimeout());
             try {
                 cachedResult = cacheServer.getCachedResult(jobHash);
-                LoggerUtil.info(listener, "(Pre-Checkout) Cached result for this job (hash: %s) is %s; found on job number %s %n", jobHash, cachedResult.result.toString(), cachedResult.build_number.toString());
+                LoggerUtil.info(listener, "(Pre-Checkout) Cached result for this job (hash: %s) is %s; found on job number %s %n", jobHash, cachedResult.getCachedResult().toString(), cachedResult.getBuildNumber().toString());
             } catch (IOException e) {
                 LoggerUtil.warn(listener, "(Pre-Checkout) Unable to get cached result for this job (hash: %s). Exception: %s %n", jobHash, e.getMessage());
             }
 
             CachedResult finalCachedResult = cachedResult;
-            if (finalCachedResult.result.equals(Result.SUCCESS)) {
+            if (finalCachedResult.getCachedResult().equals(Result.SUCCESS)) {
                 Executor executor = build.getExecutor();
                 if (executor != null) {
                     if (executor.isActive()) {
                         if (build instanceof AbstractBuild) {
                             createWorkspace(((AbstractBuild)build).getWorkspace());
                         }
-                        ParametersAction pa = new ParametersAction(Collections.singletonList(new StringParameterValue("CACHED_RESULT_BUILD_NUM", finalCachedResult.build_number.toString())), Collections.singleton("CACHED_RESULT_BUILD_NUM"));
+                        ParametersAction pa = new ParametersAction(Collections.singletonList(new StringParameterValue("CACHED_RESULT_BUILD_NUM", finalCachedResult.getBuildNumber().toString())), Collections.singleton("CACHED_RESULT_BUILD_NUM"));
                         build.addAction(pa);
-                        executor.interrupt(finalCachedResult.result, new CauseOfInterruption() {
+                        executor.interrupt(finalCachedResult.getCachedResult(), new CauseOfInterruption() {
                             @Override
                             public String getShortDescription() {
-                                return String.format(Constants.LOG_LINE_HEADER + "[INFO] This job (hash: %s) was interrupted because a SUCCESS result is cached from job number %s %n", jobHash, finalCachedResult.build_number);
+                                return String.format(Constants.LOG_LINE_HEADER + "[INFO] This job (hash: %s) was interrupted because a SUCCESS result is cached from job number %s %n", jobHash, finalCachedResult.getBuildNumber());
                             }
                         });
                     }

--- a/src/main/java/hudson/plugins/resultscache/util/CacheServerComm.java
+++ b/src/main/java/hudson/plugins/resultscache/util/CacheServerComm.java
@@ -40,22 +40,22 @@ public class CacheServerComm {
         String response = restClient.executeGet(url, defaultValue);
         JSONObject json = new JSONObject(response);
         Result result = Result.fromString(json.getString("result"));
-        Number build_number = json.getNumber("build_number");
+        Integer buildNumber = json.getInt("build_number");
 
-        return new CachedResult(result, build_number);
+        return new CachedResult(result, buildNumber);
     }
 
     /**
      * Adds or Updates a result in the cache
      * @param hash job hash to add/update
      * @param result job result. If null then NOT_BUILT
-     * @param build_number job number - allows reference to the run the result refers to. If null then -1
+     * @param buildNumber job number - allows reference to the run the result refers to. If null then -1
      * @return TRUE if it worked
      * @throws IOException there's a communication problem with the cache service
      */
-    public boolean postCachedResult(String hash, Result result, Number build_number) throws IOException {
+    public boolean postCachedResult(String hash, Result result, Integer buildNumber) throws IOException {
         Result r = (null != result) ? result : Result.NOT_BUILT;
-        Number num = (build_number != null) ? build_number : -1;
+        Integer num = (buildNumber != null) ? buildNumber : -1;
 
         String url = baseUrl + "/job-results/" + URLEncoder.encode(hash);
         String jsonInputString = "{\"result\": " + r + ", \"build_number\": " + num + "}";

--- a/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
+++ b/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
@@ -34,7 +34,7 @@ public class CacheServerCommTest {
         Thread.sleep(1000);
 
         CachedResult cachedResult = uit.getCachedResult(id);
-        Assert.assertEquals(Result.SUCCESS, cachedResult.result);
-        Assert.assertEquals(5, cachedResult.build_number);
+        Assert.assertEquals(Result.SUCCESS, cachedResult.getCachedResult());
+        Assert.assertEquals(5, cachedResult.getBuildNumber());
     }
 }

--- a/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
+++ b/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
@@ -5,6 +5,7 @@
 package hudson.plugins.resultscache.util;
 
 import hudson.model.Result;
+import hudson.plugins.resultscache.CachedResult;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -28,11 +29,12 @@ public class CacheServerCommTest {
     @Test
     public void postAndGet() throws Exception {
         String id = UUID.randomUUID().toString();
-        uit.postCachedResult(id, Result.SUCCESS);
+        uit.postCachedResult(id, Result.SUCCESS, 5);
 
         Thread.sleep(1000);
 
-        Result result = uit.getCachedResult(id);
-        Assert.assertEquals(Result.SUCCESS, result);
+        CachedResult cachedResult = uit.getCachedResult(id);
+        Assert.assertEquals(Result.SUCCESS, cachedResult.result);
+        Assert.assertEquals(5, cachedResult.build_number);
     }
 }

--- a/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
+++ b/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
@@ -35,6 +35,6 @@ public class CacheServerCommTest {
 
         CachedResult cachedResult = uit.getCachedResult(id);
         Assert.assertEquals(Result.SUCCESS, cachedResult.getCachedResult());
-        Assert.assertEquals(5, cachedResult.getBuildNumber());
+        Assert.assertEquals((Integer) 5, cachedResult.getBuildNumber());
     }
 }

--- a/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
+++ b/src/test/java/hudson/plugins/resultscache/util/CacheServerCommTest.java
@@ -35,6 +35,6 @@ public class CacheServerCommTest {
 
         CachedResult cachedResult = uit.getCachedResult(id);
         Assert.assertEquals(Result.SUCCESS, cachedResult.getCachedResult());
-        Assert.assertEquals((Integer) 5, cachedResult.getBuildNumber());
+        Assert.assertEquals(5, cachedResult.getBuildNumber().intValue());
     }
 }


### PR DESCRIPTION
Proposition to add build number of run that cached results originated from, and provide this information in an easily accessible way, to allow users - either manual, say for debugging the full run's console log, or scripted - to retrieve information from the original run. The job number from the cached run can be used along with existing run's parent job to get the full link to the cached job. In my case, this will solve an upstream job's reliance on artifacts that are saved on fully completed, successful runs (where these are still available - if not would expect the run to fail anyway).

**Notes:**
- Updated `ResultsCacheBuildWrapper.saveResultToCache(...)` to also include `build.getNumber()` from the completing build and send this to the cache
- `CacheServerComm.postCachedResult(...)` now also takes the build number, and constructs a json string with both result and build number
- Added a new `RestClientUtil.executeJsonPost(...)` rather than changing/replacing the existing `executePost(...)` in case anyone has built something bespoke that also uses this, with it being reasonably generic
- Created new `CachedResult` object to hold both the result and build number
- Updated `CacheServerComm.getCachedResult(...) to return a `CachedResult` object, and used `org.json.JSONObject` to extract the result and build number values
- Updated `CacheServerCommTest.postAndGet()` unit test
- Updated `ResultsCacheHelper.checkCacheOrExecute(...)` to including build number in logging, and create a `CACHED_RESULT_BUILD_NUM` env var, where the cached result was successful, to allow this value to be easily accessed by any scripts, etc, and used as needed
- `build_number` given as `Number` to allow same null checks as existing result implementations, with a default of -1, being an impossible actual build number