### PR TITLE
Fix adding build num environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
 *.iml
 target/
-work/
+work*/

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ wrappers {
 
 Latest release
 ==============
-2.0.1
+2.0.2
 
 How to build
 ============
@@ -78,6 +78,10 @@ How to build
 
 Version history
 ===============
+Version 2.0.2 (July 30, 2021)
+---------------------------
+* Fix: effectively add the environment variable `CACHED_RESULT_BUILD_NUM` to the build
+
 Version 2.0.1 (July 15, 2021)
 ---------------------------
 * Every cached result now also contains build number

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>com.king.jenkins.plugins</groupId>
     <artifactId>results-cache</artifactId>
     <packaging>hpi</packaging>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <name>Results Cache Plugin</name>
     <description>This plugins enables a jobs results cache in order to avoid repeated successful executions</description>
     <url>https://github.com/jenkinsci/results-cache-plugin</url>
@@ -29,7 +29,7 @@
     </licenses>
 
     <properties>
-        <revision>2.0.1</revision>
+        <revision>2.0.2</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.190.3</jenkins.version>
         <java.level>8</java.level>
@@ -45,6 +45,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
             <version>1.71</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>envinject</artifactId>
+            <version>2.1.6</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/hudson/plugins/resultscache/PluginCauseOfInterruption.java
+++ b/src/main/java/hudson/plugins/resultscache/PluginCauseOfInterruption.java
@@ -1,0 +1,21 @@
+package hudson.plugins.resultscache;
+
+import jenkins.model.CauseOfInterruption;
+
+class PluginCauseOfInterruption extends CauseOfInterruption {
+
+    private static final long serialVersionUID = -3325429860618951647L;
+
+    private final String jobHash;
+    private final Integer buildNum;
+
+    public PluginCauseOfInterruption(String jobHash, Integer buildNum) {
+        this.jobHash = jobHash;
+        this.buildNum = buildNum;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format(Constants.LOG_LINE_HEADER + "[INFO] This job (hash: %s) was interrupted because a SUCCESS result is cached from build number %s%n", jobHash, buildNum);
+    }
+}

--- a/src/main/java/hudson/plugins/resultscache/PluginConfiguration.java
+++ b/src/main/java/hudson/plugins/resultscache/PluginConfiguration.java
@@ -67,8 +67,8 @@ public class PluginConfiguration extends GlobalConfiguration {
     public FormValidation doCheckTimeout(@QueryParameter String value) {
         if (!StringUtils.isEmpty(value)) {
             try {
-                int timeout = Integer.parseInt(value);
-                if (timeout < 0) {
+                int tout = Integer.parseInt(value);
+                if (tout < 0) {
                     return FormValidation.error("Please specify a positive number.");
                 }
             } catch (NumberFormatException e) {

--- a/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
+++ b/src/main/java/hudson/plugins/resultscache/ResultsCacheHelper.java
@@ -4,26 +4,24 @@
 
 package hudson.plugins.resultscache;
 
-import org.apache.commons.lang.StringUtils;
-import java.io.IOException;
-import java.util.Collections;
-
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Executor;
-import hudson.model.ParametersAction;
 import hudson.model.Result;
 import hudson.model.Run;
-import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
 import hudson.plugins.resultscache.model.BuildConfig;
 import hudson.plugins.resultscache.util.CacheServerComm;
 import hudson.plugins.resultscache.util.HashCalculator;
 import hudson.plugins.resultscache.util.LoggerUtil;
 import jenkins.model.CauseOfInterruption;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
 
 public class ResultsCacheHelper {
 
+    public static final String CACHED_RESULT_BUILD_NUM_ENV_VAR_NAME = "CACHED_RESULT_BUILD_NUM";
     private final Run<?, ?> build;
     private final TaskListener listener;
     private final BuildConfig buildConfig;
@@ -48,7 +46,7 @@ public class ResultsCacheHelper {
 
     /**
      * Retrieves a Job Result from the Cache Server
-     * @param jobHash job hash to retrive from the cache server
+     * @param jobHash job hash to retrieve from the cache server
      * @return found Job Result or {@link JobResult#EMPTY_RESULT} otherwise
      */
     private JobResult getJobResultFromCacheServer(String jobHash) {
@@ -67,8 +65,8 @@ public class ResultsCacheHelper {
      * Process the Job Result obtained from the cache on the current build
      * @param jobHash job hash (for logging purposes)
      * @param jobResult job result
-     * @throws IOException
-     * @throws InterruptedException
+     * @throws IOException IOException
+     * @throws InterruptedException InterruptedException
      */
     private void processJobResult(String jobHash, JobResult jobResult) throws IOException, InterruptedException {
         final Result result = jobResult.getResult();
@@ -79,8 +77,7 @@ public class ResultsCacheHelper {
                 if (build instanceof AbstractBuild) {
                     createWorkspace(((AbstractBuild<?, ?>) build).getWorkspace());
                 }
-                ParametersAction pa = new ParametersAction(Collections.singletonList(new StringParameterValue("CACHED_RESULT_BUILD_NUM", buildNum.toString())), Collections.singleton("CACHED_RESULT_BUILD_NUM"));
-                build.addAction(pa);
+                build.getEnvironment(listener).put(CACHED_RESULT_BUILD_NUM_ENV_VAR_NAME, buildNum.toString());
                 executor.interrupt(result, new CauseOfInterruption() {
                     @Override
                     public String getShortDescription() {

--- a/src/main/java/hudson/plugins/resultscache/model/BuildConfig.java
+++ b/src/main/java/hudson/plugins/resultscache/model/BuildConfig.java
@@ -4,10 +4,14 @@
 
 package hudson.plugins.resultscache.model;
 
+import java.io.Serializable;
+
 /**
  * Represents a configuration for this plugin in a jenkins job.
  */
-public class BuildConfig {
+public class BuildConfig implements Serializable {
+
+    private static final long serialVersionUID = 2725731030223676965L;
 
     private boolean excludeMachineName;
     private String hashParameters;

--- a/src/main/java/hudson/plugins/resultscache/model/BuildData.java
+++ b/src/main/java/hudson/plugins/resultscache/model/BuildData.java
@@ -6,10 +6,14 @@ package hudson.plugins.resultscache.model;
 
 import hudson.EnvVars;
 
+import java.io.Serializable;
+
 /**
  * Represents a jenkins job data. It is used to create a hash to identify a jenkins job in the results cache
  */
-public class BuildData {
+public class BuildData implements Serializable {
+
+    private static final long serialVersionUID = 2502527524492021146L;
 
     private String ciUrl;
 

--- a/src/main/java/hudson/plugins/resultscache/util/LoggerUtil.java
+++ b/src/main/java/hudson/plugins/resultscache/util/LoggerUtil.java
@@ -10,7 +10,11 @@ import hudson.plugins.resultscache.Constants;
 /**
  * Logger Util utility
  */
-public class LoggerUtil {
+public final class LoggerUtil {
+
+    private LoggerUtil() {
+        throw new IllegalStateException("Utility class.");
+    }
 
     /**
      * Writes an info log trace


### PR DESCRIPTION
Fix: effectively add the environment variable `CACHED_RESULT_BUILD_NUM` to the build

* Calculate the build number to send to the cache depending on the result of the job and the presence of the ENV VAR.
* Extract inner implementation of CauseOfInterruption to avoid serialization issues
* Update README.md
* Also remove some sonar warnings